### PR TITLE
[RFC] do not execute initializeSystemHook in Install Tool

### DIFF
--- a/library/alnv/CatalogManagerInitializer.php
+++ b/library/alnv/CatalogManagerInitializer.php
@@ -15,12 +15,8 @@ class CatalogManagerInitializer {
 
     public function initialize() {
         
-        // Check if Contao has been set up yet (#210)
-        if ( !\Config::getInstance()->isComplete() ) {
-            return;
-        }
-
-        if ( TL_MODE == 'BE' ) {
+        // Do not execute in install tool (#210)
+        if ( TL_MODE == 'BE' && false === stripos( \Environment::get('requestUri'), '/contao/install' ) ) {
 
             \BackendUser::getInstance();
             \Database::getInstance();

--- a/library/alnv/CatalogManagerInitializer.php
+++ b/library/alnv/CatalogManagerInitializer.php
@@ -14,6 +14,11 @@ class CatalogManagerInitializer {
 
 
     public function initialize() {
+        
+        // Check if Contao has been set up yet
+        if ( !\Config::get('licenseAccepted') ) {
+            return;
+        }
 
         if ( TL_MODE == 'BE' ) {
 

--- a/library/alnv/CatalogManagerInitializer.php
+++ b/library/alnv/CatalogManagerInitializer.php
@@ -15,8 +15,8 @@ class CatalogManagerInitializer {
 
     public function initialize() {
         
-        // Check if Contao has been set up yet
-        if ( !\Config::get('licenseAccepted') ) {
+        // Check if Contao has been set up yet (#210)
+        if ( !\Config::getInstance()->isComplete() ) {
             return;
         }
 


### PR DESCRIPTION
If you install `alnv/catalog-manager` before the Contao Install Tool has been used to set up the installation - because you know you will need this extension for that particular project - the following error will occur when opening the Contao Install Tool:
```
octrine\DBAL\Exception\ConnectionException:
An exception occurred in driver: SQLSTATE[HY000] [1045] Access denied for user ''@'localhost' (using password: NO)

  at vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:113
  at Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception occurred in driver: SQLSTATE[HY000] [1045] Access denied for user \'\'@\'localhost\' (using password: NO)', object(PDOException))
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:184)
  at Doctrine\DBAL\DBALException::wrapException(object(Driver), object(PDOException), 'An exception occurred in driver: SQLSTATE[HY000] [1045] Access denied for user \'\'@\'localhost\' (using password: NO)')
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:169)
  at Doctrine\DBAL\DBALException::driverException(object(Driver), object(PDOException))
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php:47)
  at Doctrine\DBAL\Driver\PDOMySql\Driver->connect(array('driver' => 'pdo_mysql', 'host' => 'localhost', 'port' => 3306, 'user' => null, 'password' => null, 'dbname' => null, 'charset' => 'utf8mb4', 'driverOptions' => array(false), 'serverVersion' => '5.5', 'defaultTableOptions' => array('charset' => 'utf8mb4', 'collate' => 'utf8mb4_unicode_ci', 'engine' => 'InnoDB')), null, null, array(false))
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:389)
  at Doctrine\DBAL\Connection->connect()
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1030)
  at Doctrine\DBAL\Connection->query('SELECT DATABASE()')
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:214)
  at Doctrine\DBAL\Driver\AbstractMySQLDriver->getDatabase(object(Connection))
     (vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:274)
  at Doctrine\DBAL\Connection->getDatabase()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database.php:249)
  at Contao\Database->listTables(null, false)
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database.php:285)
  at Contao\Database->tableExists('tl_catalog')
     (vendor/alnv/catalog-manager/library/alnv/CatalogManagerInitializer.php:68)
  at CatalogManager\CatalogManagerInitializer->setCatalogs()
     (vendor/alnv/catalog-manager/library/alnv/CatalogManagerInitializer.php:34)
  at CatalogManager\CatalogManagerInitializer->initialize()
     (vendor/contao/core-bundle/src/Framework/ContaoFramework.php:372)
  at Contao\CoreBundle\Framework\ContaoFramework->triggerInitializeSystemHook()
     (vendor/contao/core-bundle/src/Framework/ContaoFramework.php:274)
  at Contao\CoreBundle\Framework\ContaoFramework->initializeFramework()
     (vendor/contao/core-bundle/src/Framework/ContaoFramework.php:127)
  at Contao\CoreBundle\Framework\ContaoFramework->initialize()
     (vendor/contao/installation-bundle/src/Controller/InstallationController.php:58)
  at Contao\InstallationBundle\Controller\InstallationController->installAction()
     (vendor/symfony/http-kernel/HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:198)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php:85)
  at Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle(object(ContaoKernel), object(Request), 1, true)
     (vendor/symfony/http-kernel/HttpCache/HttpCache.php:478)
  at Symfony\Component\HttpKernel\HttpCache\HttpCache->forward(object(Request), true, null)
     (vendor/symfony/framework-bundle/HttpCache/HttpCache.php:57)
  at Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache->forward(object(Request), true)
     (vendor/symfony/http-kernel/HttpCache/HttpCache.php:450)
  at Symfony\Component\HttpKernel\HttpCache\HttpCache->fetch(object(Request), true)
     (vendor/contao/manager-bundle/src/HttpKernel/ContaoCache.php:55)
  at Contao\ManagerBundle\HttpKernel\ContaoCache->fetch(object(Request), true)
     (vendor/symfony/http-kernel/HttpCache/HttpCache.php:347)
  at Symfony\Component\HttpKernel\HttpCache\HttpCache->lookup(object(Request), true)
     (vendor/symfony/http-kernel/HttpCache/HttpCache.php:222)
  at Symfony\Component\HttpKernel\HttpCache\HttpCache->handle(object(Request), 1, true)
     (vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php:98)
  at Contao\ManagerBundle\HttpKernel\ContaoCache->handle(object(Request))
     (web/index.php:37)
  at require('...\\web\\index.php')
     (web/app.php:4)
```
The method used here works in Contao 3.5 and 4 and is also what Contao uses to check if the Contao installation is complete yet.