### PR TITLE
Do not return null in ContentElement::generate

### DIFF
--- a/library/alnv/Elements/ContentCatalogFilterForm.php
+++ b/library/alnv/Elements/ContentCatalogFilterForm.php
@@ -35,12 +35,12 @@ class ContentCatalogFilterForm extends \ContentElement {
 
         if ( !$this->objForm->getState() ) {
 
-            return null;
+            return '';
         }
 
         if ( $this->objForm->disableAutoItem() ) {
 
-            return null;
+            return '';
         }
 
         return parent::generate();


### PR DESCRIPTION
The `generate` method of `Contao\ContentElement` is expected to always return a string:

https://github.com/contao/contao/blob/a13d7753d65d7c516ec325e1f02ab69854267eee/core-bundle/src/Resources/contao/elements/ContentElement.php#L223-L233

Currently however the `CatalogManager\ContentCatalogFilterForm` might return `null` instead, which can lead to errors in a `getContentElement` hook for example, if strict types are enabled.

The `CatalogManager\ContentCatalogEntity` element already does this correctly:

https://github.com/alnv/catalog-manager/blob/9fbc355d6df1883bd610b36f4c2bd712add4914a/library/alnv/Elements/ContentCatalogEntity.php#L26-L34