### PR TITLE
Fix type error in CatalogView

### DIFF
--- a/library/alnv/CatalogView.php
+++ b/library/alnv/CatalogView.php
@@ -1150,7 +1150,7 @@ class CatalogView extends CatalogController {
         if (Toolkit::isEmpty($strType)) return $varValue;
         if ($this->isFastMode($strType, $strFieldname)) return '';
 
-        $arrImgSize = \StringUtil::deserialize($this->arrOptions['imgSize']);
+        $arrImgSize = \StringUtil::deserialize($this->arrOptions['imgSize'], true);
         if (!empty(array_filter($arrImgSize))) $arrField['size'] = $this->arrOptions['imgSize'];
 
         switch ($strType) {


### PR DESCRIPTION
This fixes the following error under PHP 8:

```
TypeError:
array_filter(): Argument #1 ($array) must be of type array, string given

  at vendor\alnv\catalog-manager\library\alnv\CatalogView.php:1154
  at array_filter('')
```