### PR TITLE
Fix wrong type warning

### DIFF
--- a/library/alnv/CatalogDcExtractor.php
+++ b/library/alnv/CatalogDcExtractor.php
@@ -473,7 +473,7 @@ class CatalogDcExtractor extends CatalogController {
             '_tables' => [],
             'enableVersioning' => (bool) $arrCatalog['useVC'] ?? '',
             'ptable' => $arrReturn[$strDcConfigType]['ptable'] ?? '',
-            'ctable' => $arrReturn[$strDcConfigType]['ctable'] ?? '',
+            'ctable' => $arrReturn[$strDcConfigType]['ctable'] ?? [],
             'onsubmit_callback' => is_array($arrReturn[$strDcConfigType]['onsubmit_callback']) ? $arrReturn[$strDcConfigType]['onsubmit_callback'] : []
         ];
 


### PR DESCRIPTION
Fixes the warning "in_array() expects parameter 2 to be array, string given" for line 491:

https://github.com/alnv/catalog-manager/blob/e624479cc820226b6614b7725384ac664f37a222/library/alnv/CatalogDcExtractor.php#L491