### PR TITLE
Fix PHP Warning: Undefined array key "_core"

### DIFF
--- a/library/alnv/CatalogParser.php
+++ b/library/alnv/CatalogParser.php
@@ -32,7 +32,7 @@ class CatalogParser extends CatalogController {
 
         foreach ( $arrFields as $strFieldname => $arrField ) {
 
-            if ( !$arrField['_core'] ) $this->arrFields[ $strFieldname ] = $arrField;
+            if ( !isset( $arrField['_core'] ) ) $this->arrFields[ $strFieldname ] = $arrField;
         }
     }
 


### PR DESCRIPTION
Currently I get following error message using PHP 8.1:
`PHP message:PHP Warning:  Undefined array key "_core" in [path]/vendor/alnv/catalog-manager/library/alnv/CatalogParser.php on line 35`

This PR should fix this warning.