### PR TITLE
add contao-community-alliance plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   "require": {
     "php":">=7.2",
     "tecnickcom/tcpdf": "^6.2",
+    "contao-community-alliance/composer-plugin":"~2.4 || ~3.0",
     "contao/core-bundle":"^4.4"
   },
   "replace": {


### PR DESCRIPTION
Add contao-community-alliance plugin, otherwise no symlink will be generated in system/modules. The CM cannot be used without it.

Tested with: PHP7.4 / Contao 4.13.8