### PR TITLE
Add cache tags

### DIFF
--- a/library/alnv/CatalogView.php
+++ b/library/alnv/CatalogView.php
@@ -2,6 +2,8 @@
 
 namespace CatalogManager;
 
+use Contao\System;
+
 
 class CatalogView extends CatalogController
 {
@@ -767,6 +769,17 @@ class CatalogView extends CatalogController
             }
 
             $arrCatalogs[] = $arrCatalog;
+        }
+
+        if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger')) {
+            $responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+            $tag = 'contao.db.'.$this->catalogTablename;
+
+            if ('view' === $this->strMode) {
+                $responseTagger->addTags([$tag]);
+            } elseif ('master' === $this->strMode) {
+                $responseTagger->addTags(array_map(static function ($record) use ($tag) { return $tag.'.'.$record['id']; }, $arrCatalogs));
+            }
         }
 
         if ($intPerPage > 0 && $this->catalogAddPagination && $this->strMode == 'view') {


### PR DESCRIPTION
I am not sure how much support this repository and branch still gets - so feel free to ignore :)

Currently when editing a record in the back end, the HTTP cache is not cleared, since no cache tags are added in the front end.

Let's say you have a table called `foobar` in Catalog Manager. When you edit something in the back end, Contao will automatically clear the cache for the following tags:

* `contao.db.foobar`
* `contao.db.foobar.42` (with 42 being the ID of the edited record)

This PR adds the following cache tags:

* `contao.db.foobar` in the list view - so when a record gets edited, all list view of that table get cleared from the cache.
* `contao.db.foobar.42` in the detail view - so when a record gets edited, the detail URL of that record gets cleared from the cache.