### PR TITLE
Fetch all catalog tables at once to avoid conflicts with buffered query results

### DIFF
--- a/src/EventListener/DoctrineSchemaListener.php
+++ b/src/EventListener/DoctrineSchemaListener.php
@@ -21,16 +21,16 @@ class DoctrineSchemaListener
         }
 
         $objSchema = $event->getSchema();
-        $objCatalogs = Database::getInstance()->prepare('SELECT * FROM tl_catalog ORDER BY `tablename`')->execute();
+        $objCatalogs = Database::getInstance()->prepare('SELECT * FROM tl_catalog ORDER BY `tablename`')->execute()->fetchAllAssoc();
 
-        while ($objCatalogs->next()) {
+        foreach ($objCatalogs as $objCatalog) {
 
-            if (!$objCatalogs->tablename) {
+            if (!$objCatalog->tablename) {
                 continue;
             }
 
-            $objTable = $objSchema->hasTable($objCatalogs->tablename) ? $objSchema->getTable($objCatalogs->tablename) : $objSchema->createTable($objCatalogs->tablename);
-            $arrFields = Database::getInstance()->listFields($objCatalogs->tablename);
+            $objTable = $objSchema->hasTable($objCatalog->tablename) ? $objSchema->getTable($objCatalog->tablename) : $objSchema->createTable($objCatalog->tablename);
+            $arrFields = Database::getInstance()->listFields($objCatalog->tablename);
 
             foreach ($arrFields as $strIndex => $arrField) {
 


### PR DESCRIPTION
When upgrading a Contao project from 4.13 to 5.3. I ran in to the folllwing error message:

```
General error: 2014 Cannot execute queries while other unbuffered queries are active. Consider using PDOStatement::fetchAll(). …
```

This was caused by running queries inside the while loop. This PR fixes this by loading all catalog tables at once. 